### PR TITLE
Fix code generation (method declarations accumulating due to Result not initalized)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,5 @@ dbus2pas -p /org/freedesktop/Notifications \
     -c GenerateInterface,GenerateProxy,UseFunction,LastPartInterfaceName
 ```
 This will create a file called `org_freedesktop_Notifications.pas` containing code with an Interface and a Proxy to the org.freedesktop.Notifications service.
+
+You will need to include `org_freedesktop_Notifications.pas` and `dbusproxy.pp` in your project.

--- a/gui/frmmain.pp
+++ b/gui/frmmain.pp
@@ -410,6 +410,7 @@ end;
 Function TMainForm.ObjectpathFromNode(N : TTreeNode) : String;
 
 begin
+  Result:='';
   While (N<>Nil) do
     begin
     Result:=N.Text+Result;
@@ -639,11 +640,10 @@ Var
   I : Integer;
   S,D : String;
   N : TTreeNode;
-  V : TDBUSvarDef;
 begin
   S:=DBUSPascalTypeNames[AProperty.DataType];
-  If (V.DataType=ddtArray) then
-    S:=S+DBUSPascalTypeNames[V.ElementType];
+  If (AProperty.DataType=ddtArray) then
+    S:=S+' of '+DBUSPascalTypeNames[AProperty.ElementType];
   Case AProperty.Access of
     dpaRead : S:=S+' (read-only)';
     dpaWrite : S:=S+' (write-only)';

--- a/src/dbusintro.pp
+++ b/src/dbusintro.pp
@@ -1418,6 +1418,7 @@ begin
   LA:=AMethod.Arguments.Count-1;
   If IsF then
     isf:=(La>=0) and (AMethod.Arguments[LA].Direction=adOut);
+  Result:='';
   For I:=0 to AMethod.Arguments.Count-1-Ord(Isf) do
     begin
     If (Result<>'') then


### PR DESCRIPTION
The main issue was due to `Result` not being initialized, causing generated code to look like this:

```
TNotificationsProxy = Class(TDBUSProxy)
Protected
  Function DBUSPropGetInhibited : Boolean;
Public
  Procedure Notify (Function DBUSPropGetInhibited : Boolean;;Arg1 : Cardinal;app_name : String;replaces_id : Cardinal;app_icon : String;summary : String;body : String;actions : TStringArray;hints : TNotificationsNotifyhints;timeout : Integer);
  Procedure CloseNotification (Procedure Notify (Function DBUSPropGetInhibited : Boolean;;Arg1 : Cardinal;app_name : String;replaces_id : Cardinal;app_icon : String;summary : String;body : String;actions : TStringArray;hints : TNotificationsNotifyhints;timeout : Integer);id : Cardinal);
  Function GetCapabilities (Procedure CloseNotification (Procedure Notify (Function DBUSPropGetInhibited : Boolean;;Arg1 : Cardinal;app_name : String;replaces_id : Cardinal;app_icon : String;summary : String;body : String;actions : TStringArray;hints : TNotificationsNotifyhints;timeout : Integer);id : Cardinal))GetCapabilities : TStringArray;
```

Both issues were seen in compiler warnings:

```
Warning: function result variable of a managed type does not seem to be initialized
Warning: Local variable "V" does not seem to be initialized
```